### PR TITLE
PRevent the user from exporting something different from someone else

### DIFF
--- a/io_antarctica_scene/stk_kart.py
+++ b/io_antarctica_scene/stk_kart.py
@@ -277,15 +277,7 @@ def exportKart(self, path):
 
     # Get the kart and all wheels
     # ---------------------------
-    objSel = bpy.context.preferences.addons[os.path.basename(os.path.dirname(__file__))].preferences.stk_object_selection
-    if objSel == "selected":
-        lObj = bpy.context.selected_objects
-    elif objSel == "scene":
-        lObj = bpy.context.scene.objects
-    elif objSel == "view-layer":
-        lObj = bpy.view_layer.objects
-    else:
-        lObj = bpy.data.objects
+    lObj = bpy.data.objects
 
     lWheels       = []
     lKart         = []

--- a/io_antarctica_scene/stk_panel.py
+++ b/io_antarctica_scene/stk_panel.py
@@ -483,15 +483,6 @@ class StkPanelAddonPreferences(bpy.types.AddonPreferences):
             #subtype='DIR_PATH',
             )
 
-    stk_object_selection: bpy.props.EnumProperty(
-            name="Object selection type",
-            items=(("all", "All", "All objects across every scene, view layer (may fail if there are hidden objects)"),
-               ("scene", "Scene", "All objects in the active scene"),
-               ("view-layer", "View Layer", "All objects in the active view layer"),
-               ("selected", "Selected", "Selected objects only")),
-            default="scene",
-            )
-
     stk_delete_old_files_on_export: bpy.props.BoolProperty(
             name="Delete all old files when exporting a track in a folder (*.spm)",
             default = False

--- a/io_antarctica_scene/stk_track.py
+++ b/io_antarctica_scene/stk_track.py
@@ -1065,15 +1065,7 @@ class TrackExport:
 
         # Collect the different kind of meshes this exporter handles
         # ----------------------------------------------------------
-        objSel = bpy.context.preferences.addons[os.path.basename(os.path.dirname(__file__))].preferences.stk_object_selection
-        if objSel == "selected":
-            lObj = bpy.context.selected_objects
-        elif objSel == "scene":
-            lObj = bpy.context.scene.objects
-        elif objSel == "view-layer":
-            lObj = bpy.view_layer.objects
-        else:
-            lObj = bpy.data.objects
+        lObj = bpy.context.scene.objects
 
         lTrack               = []                    # All main track objects
         lCameraCurves        = []                    # Camera curves (unused atm)


### PR DESCRIPTION
Users should not be able to export selected objects. If someone build a map like this and someone else open the blend file they will have no idea which objects where selected.