### PR TITLE
Always precompute tangents & remove dangerous options

### DIFF
--- a/extras/export_stk_object_cmd.py
+++ b/extras/export_stk_object_cmd.py
@@ -118,12 +118,10 @@ def main():
         except:
             print("Warning: File " + args.file + " does not contain a SuperTuxKart object, exporting as an SPM model")
             bpy.ops.screen.spm_export(localsp=False, filepath=args.save_path, selected=False, \
-                                  export_tangent='precalculate_tangents' in bpy.context.scene\
-                                  and bpy.context.scene['precalculate_tangents'] == 'true')
+                                  export_tangent=True)
     elif args.spm and not args.kart and not args.track and not args.materials:
         bpy.ops.screen.spm_export(localsp=False, filepath=args.save_path, selected=False, \
-                                  export_tangent='precalculate_tangents' in bpy.context.scene\
-                                  and bpy.context.scene['precalculate_tangents'] == 'true')
+                                  export_tangent=True)
     elif args.kart and not args.track and not args.materials and not args.spm:
         bpy.ops.screen.stk_kart_export(filepath=args.save_path)
     elif args.track and not args.kart and not args.materials and not args.spm:

--- a/io_antarctica_scene/stk_kart.py
+++ b/io_antarctica_scene/stk_kart.py
@@ -277,15 +277,7 @@ def exportKart(self, path):
 
     # Get the kart and all wheels
     # ---------------------------
-    objSel = bpy.context.preferences.addons[os.path.basename(os.path.dirname(__file__))].preferences.stk_object_selection
-    if objSel == "selected":
-        lObj = bpy.context.selected_objects
-    elif objSel == "scene":
-        lObj = bpy.context.scene.objects
-    elif objSel == "view-layer":
-        lObj = bpy.view_layer.objects
-    else:
-        lObj = bpy.data.objects
+    lObj = bpy.data.objects
 
     lWheels       = []
     lKart         = []

--- a/io_antarctica_scene/stk_kart.py
+++ b/io_antarctica_scene/stk_kart.py
@@ -76,8 +76,7 @@ def saveHeadlights(self, f, lHeadlights, path, straight_frame):
 
             obj.select_set(True)
             bpy.ops.screen.spm_export(localsp=True, filepath=path + "/" + exported_name, selection_type="selected", \
-                                      export_tangent='precalculate_tangents' in bpy.context.scene\
-                                      and bpy.context.scene['precalculate_tangents'] == 'true')
+                                      export_tangent=True)
             obj.select_set(False)
 
         flags.append('           model="%s"/>\n' % exported_name)
@@ -132,8 +131,7 @@ def saveSpeedWeighted(self, f, lSpeedWeighted, path, straight_frame):
 
             obj.select_set(True)
             bpy.ops.screen.spm_export(localsp=True, filepath=path + "/" + exported_name, selection_type="selected", \
-                                      export_tangent='precalculate_tangents' in bpy.context.scene\
-                                      and bpy.context.scene['precalculate_tangents'] == 'true')
+                                      export_tangent=True)
             obj.select_set(False)
 
         flags.append('           model="%s"/>\n' % exported_name)
@@ -173,8 +171,7 @@ def saveWheels(self, f, lWheels, path):
 
         wheel.select_set(True)
         bpy.ops.screen.spm_export(localsp=False, filepath=path + "/" + lWheelNames[index], selection_type="selected", \
-                                  export_tangent='precalculate_tangents' in bpy.context.scene\
-                                  and bpy.context.scene['precalculate_tangents'] == 'true')
+                                  export_tangent=True)
         wheel.select_set(False)
 
         wheel.location = lOldPos
@@ -393,8 +390,7 @@ def exportKart(self, path):
 
     stk_utils.selectObjectsInList(lKart)
     bpy.ops.screen.spm_export(localsp=False, filepath=path+"/"+model_file, selection_type="selected", \
-                              export_tangent='precalculate_tangents' in bpy.context.scene\
-                              and bpy.context.scene['precalculate_tangents'] == 'true', \
+                              export_tangent=True, \
                               static_mesh_frame = straight_frame)
     bpy.ops.object.select_all(action='DESELECT')
     stk_utils.hideTransientObjects();

--- a/io_antarctica_scene/stk_kart.py
+++ b/io_antarctica_scene/stk_kart.py
@@ -274,7 +274,7 @@ def exportKart(self, path):
 
     # Get the kart and all wheels
     # ---------------------------
-    lObj = bpy.data.objects
+    lObj = bpy.context.scene.objects
 
     lWheels       = []
     lKart         = []

--- a/io_antarctica_scene/stk_panel.py
+++ b/io_antarctica_scene/stk_panel.py
@@ -483,15 +483,6 @@ class StkPanelAddonPreferences(bpy.types.AddonPreferences):
             #subtype='DIR_PATH',
             )
 
-    stk_object_selection: bpy.props.EnumProperty(
-            name="Object selection type",
-            items=(("all", "All", "All objects across every scene, view layer (may fail if there are hidden objects)"),
-               ("scene", "Scene", "All objects in the active scene"),
-               ("view-layer", "View Layer", "All objects in the active view layer"),
-               ("selected", "Selected", "Selected objects only")),
-            default="scene",
-            )
-
     stk_delete_old_files_on_export: bpy.props.BoolProperty(
             name="Delete all old files when exporting a track in a folder (*.spm)",
             default = False

--- a/io_antarctica_scene/stk_track.py
+++ b/io_antarctica_scene/stk_track.py
@@ -1065,15 +1065,7 @@ class TrackExport:
 
         # Collect the different kind of meshes this exporter handles
         # ----------------------------------------------------------
-        objSel = bpy.context.preferences.addons[os.path.basename(os.path.dirname(__file__))].preferences.stk_object_selection
-        if objSel == "selected":
-            lObj = bpy.context.selected_objects
-        elif objSel == "scene":
-            lObj = bpy.context.scene.objects
-        elif objSel == "view-layer":
-            lObj = bpy.view_layer.objects
-        else:
-            lObj = bpy.data.objects
+        lObj = bpy.context.scene.objects
 
         lTrack               = []                    # All main track objects
         lCameraCurves        = []                    # Camera curves (unused atm)

--- a/io_antarctica_scene/stk_track.py
+++ b/io_antarctica_scene/stk_track.py
@@ -174,7 +174,7 @@ class TrackExport:
         obj.select_set(True)
         try:
             bpy.ops.screen.spm_export(localsp=True, filepath=sPath+"/"+name, selection_type="selected", \
-                                      export_tangent=stk_utils.getSceneProperty(bpy.context.scene, 'precalculate_tangents', 'false') == 'true',
+                                      export_tangent=True,
                                       applymodifiers=applymodifiers)
         except:
             self.log.report({'ERROR'}, "Failed to export " + name)
@@ -1158,7 +1158,7 @@ class TrackExport:
         stk_utils.selectObjectsInList(lTrack)
         if exportScene and stk_utils.getSceneProperty(bpy.data.scenes[0], 'is_stk_node', 'false') != 'true':
             bpy.ops.screen.spm_export(localsp=False, filepath=sPath+"/"+sTrackName, selection_type="selected", \
-                                      export_tangent=stk_utils.getSceneProperty(scene, 'precalculate_tangents', 'false') == 'true')
+                                      export_tangent=True == 'true')
         bpy.ops.object.select_all(action='DESELECT')
         stk_utils.hideTransientObjects();
 

--- a/io_antarctica_scene/stkdata/stk_panel_parameters.xml
+++ b/io_antarctica_scene/stkdata/stk_panel_parameters.xml
@@ -3,9 +3,6 @@
     bl-label="SuperTuxKart Scene Properties"
 >
 
-<BoolProp id="precalculate_tangents" name="Pre-calculate tangents in .spm when export" default="false" box="false" doc="Use this only when you need 100% correct normal mapping for the objects in the scene">
-</BoolProp>
-
 <BoolProp id="is_stk_node" name="Is a SuperTuxKart library node" default="false" box="false" doc="Check this if this blender file is a SuperTuxKart library node">
     <StringProp id="name" name="Code (folder name)" default="myNewNode" doc="Name of the node"/>
 </BoolProp>


### PR DESCRIPTION
- Tangents should always be precomputed. If not they can create weird artifacts when using normal maps.

- Users should not be able to export selected objects. If someone build a map like this and someone else open the blend file they will have no idea which objects where selected.