### PR TITLE
Do not use object proxies in blender 3.x

### DIFF
--- a/io_antarctica_scene/stk_panel.py
+++ b/io_antarctica_scene/stk_panel.py
@@ -256,10 +256,11 @@ class STK_PT_Object_Panel(bpy.types.Panel, PanelBase):
             return
 
         obj = context.object
-
-        if obj.proxy is not None:
-            layout.label(text="Library nodes cannot be configured here")
-            return
+        
+        if bpy.obj.version < (3, 0, 0):
+            if obj.proxy is not None:
+                layout.label(text="Library nodes cannot be configured here")
+                return
 
         if obj is not None:
             if is_track or is_node:

--- a/io_antarctica_scene/stk_panel.py
+++ b/io_antarctica_scene/stk_panel.py
@@ -257,7 +257,7 @@ class STK_PT_Object_Panel(bpy.types.Panel, PanelBase):
 
         obj = context.object
         
-        if bpy.obj.version < (3, 0, 0):
+        if bpy.app.version < (3, 0, 0):
             if obj.proxy is not None:
                 layout.label(text="Library nodes cannot be configured here")
                 return

--- a/io_antarctica_scene/stk_track_utils.py
+++ b/io_antarctica_scene/stk_track_utils.py
@@ -222,10 +222,11 @@ class BlenderHairExporter:
                        (loc[0], loc[2], loc[1], -hpr[0]*rad2deg, -hpr[2]*rad2deg,
                         -hpr[1]*rad2deg, si, si, si)
 
-                    if instance_obj.proxy is not None and instance_obj.proxy.library is not None:
-                        path_parts = re.split("/|\\\\", instance_obj.proxy.library.filepath)
-                        lib_name = path_parts[-2]
-                        f.write('  <library name="%s" id=\"%s\" %s/>\n' % (lib_name, instance_obj.name, loc_rot_scale_str))
+                    if bpy.app.version < (3, 0, 0):
+                        if instance_obj.proxy is not None and instance_obj.proxy.library is not None:
+                            path_parts = re.split("/|\\\\", instance_obj.proxy.library.filepath)
+                            lib_name = path_parts[-2]
+                            f.write('  <library name="%s" id=\"%s\" %s/>\n' % (lib_name, instance_obj.name, loc_rot_scale_str))
                     else:
                         name     = stk_utils.getObjectProperty(instance_obj, "name",   instance_obj.name )
                         if len(name) == 0:
@@ -410,17 +411,19 @@ class LibraryNodeExporter:
 
     def processObject(self, object, stktype):
 
-        if object.proxy is not None and object.proxy.library is not None:
-            self.m_objects.append(object)
-            return True
-        else:
-            return False
+        if bpy.app.version < (3, 0, 0):
+            if object.proxy is not None and object.proxy.library is not None:
+                self.m_objects.append(object)
+                return True
+            else:
+                return False
 
     def export(self, f):
         import re
         for obj in self.m_objects:
             try:
-                path_parts = re.split("/|\\\\", obj.proxy.library.filepath)
+                if bpy.app.version < (3, 0, 0):
+                    path_parts = re.split("/|\\\\", obj.proxy.library.filepath)
                 lib_name = path_parts[-2]
 
                 # origin

--- a/io_antarctica_scene/stk_utils.py
+++ b/io_antarctica_scene/stk_utils.py
@@ -66,11 +66,12 @@ def getSceneProperty(scene, name, default="", set_value_if_undefined=1):
 # ------------------------------------------------------------------------------
 # Gets a custom property of an object
 def getObjectProperty(obj, name, default=""):
-    if obj.proxy is not None:
-        try:
-            return obj.proxy[name]
-        except:
-            pass
+    if bpy.app.version < (3, 0, 0):
+        if obj.proxy is not None:
+            try:
+                return obj.proxy[name]
+            except:
+                pass
 
     try:
         return obj[name]


### PR DESCRIPTION
This PR prevents the use of object proxies in the io_antarctica_scene when using blender 3+, to prevent the addon from failing at export time and failing to show stk object properties.
This does not provide the code to support the blender 3+ equivalent feature (library overriding), so library nodes will probably not work in blender 3+, (but the addon should be at least usable).