### PR TITLE
Fix checkline dropdowns to use group names and include 'lap' option

### DIFF
--- a/io_antarctica_scene/stk_utils.py
+++ b/io_antarctica_scene/stk_utils.py
@@ -395,7 +395,7 @@ class StkObjectReferenceProperty(StkProperty):
                             seen_objs[object_id] = True
 
                 for curr in self.m_static_objects:
-                    layout.operator("scene.stk_select_object_"+self.m_property_id, text=curr[1]).name=curr[0]
+                    layout.operator(select_op_name, text=curr[1]).name=curr[0]
 
 
         bpy.utils.register_class(ObjectPickerMenu)

--- a/io_antarctica_scene/stkdata/stk_object_parameters.xml
+++ b/io_antarctica_scene/stkdata/stk_object_parameters.xml
@@ -474,6 +474,7 @@
             <StringProp id="name" name="Name" default="" doc="Name of the checkline"/>
             <ObjRefProp id="activate" name="Activate" default="" static_objects="[('lap','Lap')]"
                         filter="lambda self, o : 'type' in o and o['type'] == 'check'"
+                        obj_identifier="lambda self, o : o['name']"
                         doc="Which check structure to activate when crossing this checkline"/>
         </EnumChoice>
         <EnumChoice id="driveline" label="Driveline (additional)" doc="Driveline used to mark an alternate path" >
@@ -489,6 +490,7 @@
         <EnumChoice id="maindriveline" label="Driveline (main)" doc="The main driveline used to mark where karts may drive" >
             <ObjRefProp id="activate" name="Activate" default=""
                         filter="lambda self, o : 'type' in o and o['type'] == 'check'"
+                        obj_identifier="lambda self, o : o['name']"
                         doc="Which check structure to activate when crossing the lap line"/>
             <FloatProp id="min_height_testing" name="Min height testing" default="-1.0" doc="Vertical height smaller this value will not be considered on-quad"/>
             <FloatProp id="max_height_testing" name="Max height testing" default="5.0" doc="Vertical height larger this value will not be considered on-quad"/>
@@ -507,6 +509,7 @@
         <EnumChoice id="lap" label="Lap line" doc="An extension to the factory lap line">
             <ObjRefProp id="activate" name="Activate" default=""
                         filter="lambda self, o : 'type' in o and o['type'] == 'check'"
+                        obj_identifier="lambda self, o : o['name']"
                         doc="Which check structure to activate when crossing the lap line"/>
         </EnumChoice>
         


### PR DESCRIPTION
Fixes https://github.com/supertuxkart/stk-blender/issues/19
Also fixes 'lap' not appearing as a default option for checklines.