### PR TITLE
Fix for the .spm importer not working in Blender 4.0 onwards

### DIFF
--- a/io_scene_spm/import_spm.py
+++ b/io_scene_spm/import_spm.py
@@ -37,7 +37,10 @@ def create_material(tex_fname_1, tex_fname_2, tex_name_1, tex_name_2):
     assert principled_node.type == 'BSDF_PRINCIPLED'
     x, y = principled_node.location
     # Make it less shiny
-    principled_node.inputs["Specular IOR Level"].default_value = 0
+    if (4, 0, 0) > bpy.app.version: # Old specular name before Blender 4.0
+        principled_node.inputs["Specular"].default_value = 0
+    else: # New specular name
+        principled_node.inputs["Specular IOR Level"].default_value = 0
     principled_node.inputs["Roughness"].default_value = 1
 
     if tex_fname_1:

--- a/io_scene_spm/import_spm.py
+++ b/io_scene_spm/import_spm.py
@@ -37,7 +37,7 @@ def create_material(tex_fname_1, tex_fname_2, tex_name_1, tex_name_2):
     assert principled_node.type == 'BSDF_PRINCIPLED'
     x, y = principled_node.location
     # Make it less shiny
-    principled_node.inputs["Specular"].default_value = 0
+    principled_node.inputs["Specular IOR Level"].default_value = 0
     principled_node.inputs["Roughness"].default_value = 1
 
     if tex_fname_1:


### PR DESCRIPTION
The python name for the specular input got changed in Blender 4.0 with the [Principled BSDF re-factor](https://developer.blender.org/docs/release_notes/4.0/python_api/#shader-nodes).

This fixes ensures that the .spm importer works on any Blender version by checking the current version and using the appropriate specular input name for it.