### PR TITLE
proxy compatibility return 2.8 +

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2009-2020 SuperTuxKart-Team
+Copyright (c) 2009-2025 SuperTuxKart-Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/io_antarctica_scene/blender_manifest.toml
+++ b/io_antarctica_scene/blender_manifest.toml
@@ -4,17 +4,24 @@ id = "io_antarctica_scene"
 version = "4.0.0"
 name = "SuperTuxKart Exporter Tools"
 tagline = "Export items to SuperTuxKart (karts/tracks/materials)"
-maintainer = "Richard Qian, LLS"
+maintainer = "Richard Qian, LLS, Alayan"
 
 type = "add-on"
 website = "https://supertuxkart.net/Main_Page.html"
 tags = ["Import-Export"]
 
-blender_version_min = "2.80.0"
+# The extension works with Blender 3.0.0 or greater
+# 4.2.0 is the minimum here because that's the minimum
+# for the new Blender Extensions system
+blender_version_min = "4.2.0"
 # blender_version_max = "5.1.0"
-license = [
-  "SPDX:MIT",
-]
+
+# The addon is actually available under the MIT license.
+# Because the GPL is more restrictive, we can distribute
+# it on Blender Extensions under the terms of the GPL.
+# Users who wish to get it under the MIT license can simply
+# get the code on the official repository.
+license = ['SPDX:GPL-3.0-or-later']
 # # Optional: required by some licenses.
 copyright = [
    "2009-2025 SuperTuxKart-Team",
@@ -22,3 +29,6 @@ copyright = [
    "Dev Joerg Henrichs",
    "Dev Marianne Gagnon",
 ]
+
+[permissions]
+files = "Import/export STK objects from/to disk"

--- a/io_antarctica_scene/stk_panel.py
+++ b/io_antarctica_scene/stk_panel.py
@@ -61,6 +61,16 @@ if os.path.exists(datapath):
 else:
     raise RuntimeError("(STK) Make sure the stkdata folder is installed, cannot locate it!!")
 
+def get_proxy(obj):
+    if bpy.app.version < (3, 0, 0):
+        if obj.proxy is not None:
+            return True
+    elif bpy.app.version >= (3, 0, 0):
+        if obj.library is not None or obj.override_library is not None:
+            return True
+    else:
+        return False
+
 class STK_TypeUnset(bpy.types.Operator):
     bl_idname = ("screen.stk_unset_type")
     bl_label = ("STK Object :: unset type")
@@ -257,7 +267,7 @@ class STK_PT_Object_Panel(bpy.types.Panel, PanelBase):
 
         obj = context.object
 
-        if obj.library is not None or obj.override_library is not None:
+        if get_proxy(obj):
             layout.label(text="Library nodes cannot be configured here")
             return
 

--- a/io_antarctica_scene/stk_track_utils.py
+++ b/io_antarctica_scene/stk_track_utils.py
@@ -26,6 +26,18 @@ from . import stk_track, stk_utils
 
 # --------------------------------------------------------------------------
 
+def get_proxy(obj):
+    if bpy.app.version < (3, 0, 0):
+        if obj.proxy is not None and obj.proxy.library is not None:
+            return obj
+    elif bpy.app.version >= (3, 0, 0):
+        if obj.library is not None or obj.override_library is not None:
+            return obj
+    else:
+        return False
+    
+# --------------------------------------------------------------------------
+
 def writeBezierCurve(f, curve, speed, extend="cyclic"):
     matrix = curve.matrix_world
     if len(curve.data.splines) > 1:
@@ -221,8 +233,11 @@ class BlenderHairExporter:
                     loc_rot_scale_str = "xyz=\"%.2f %.2f %.2f\" hpr=\"%.1f %.1f %.1f\" scale=\"%.2f %.2f %.2f\"" %\
                        (loc[0], loc[2], loc[1], -hpr[0]*rad2deg, -hpr[2]*rad2deg,
                         -hpr[1]*rad2deg, si, si, si)
-
-                    if instance_obj.library is not None or instance_obj.override_library is not None:
+                    # blender < 3.2
+                    if bpy.app.version < (3, 0, 0) and instance_obj.proxy is not None and instance_obj.proxy.library is not None:
+                        path_parts = re.split("/|\\\\", instance_obj.proxy.library.filepath)
+                    # blender >= 3.2
+                    elif bpy.app.version >= (3, 0, 0)and instance_obj.library is not None or instance_obj.override_library is not None:
                         if obj.library is not None:
                             path_parts = re.split("/|\\\\", obj.library.filepath)
                         else:
@@ -412,8 +427,7 @@ class LibraryNodeExporter:
         self.log = log
 
     def processObject(self, object, stktype):
-
-        if object.library is not None or object.override_library is not None:
+        if get_proxy(object):
             self.m_objects.append(object)
             return True
         else:
@@ -423,10 +437,13 @@ class LibraryNodeExporter:
         import re
         for obj in self.m_objects:
             try:
-                if obj.library is not None:
-                    path_parts = re.split("/|\\\\", obj.library.filepath)
-                else:
-                    path_parts = re.split("/|\\\\", obj.override_library.reference.library.filepath)
+                if bpy.app.version < (3, 0, 0):
+                    path_parts = re.split("/|\\\\", obj.proxy.library.filepath)
+                if bpy.app.version >= (3, 0, 0):
+                    if obj.library is not None:
+                        path_parts = re.split("/|\\\\", obj.library.filepath)
+                    else:
+                        path_parts = re.split("/|\\\\", obj.override_library.reference.library.filepath)
                 lib_name = path_parts[-2]
 
                 # origin

--- a/io_antarctica_scene/stk_utils.py
+++ b/io_antarctica_scene/stk_utils.py
@@ -66,14 +66,19 @@ def getSceneProperty(scene, name, default="", set_value_if_undefined=1):
 # ------------------------------------------------------------------------------
 # Gets a custom property of an object
 def getObjectProperty(obj, name, default=""):
-    if obj.library is not None or obj.override_library is not None:
-        try:
-            if obj.library is not None:
-                return obj.library[name]
-            else:
-                return obj.override_library.reference.library[name]
-        except:
-            pass
+    if bpy.app.version < (3, 0, 0):
+        if obj.proxy is not None:
+            try: 
+                return obj.proxy[name]
+            except: pass
+    if bpy.app.version >= (3, 0, 0):
+        if obj.library is not None or obj.override_library is not None:
+            try:
+                if obj.library is not None:
+                    return obj.library[name]
+                else:
+                    return obj.override_library.reference.library[name]
+            except: pass
 
     try:
         return obj[name]

--- a/io_scene_spm/__init__.py
+++ b/io_scene_spm/__init__.py
@@ -21,11 +21,11 @@
 # SOFTWARE.
 
 bl_info = {
-    "name": "SPM (Space paritioned mesh) format",
+    "name": "SPM (Space partitioned mesh) format",
     "author": "Benau, Richard Qian, LLS",
     "description": "Import-Export from or to the SPM format (the SuperTuxKart mesh format)",
     "version": (2,0),
-    "blender": (2, 80, 0),
+    "blender": (3, 0, 0),
     "location": "File > Import-Export",
     "wiki_url": "https://supertuxkart.net/Community",
     "tracker_url": "https://github.com/supertuxkart/stk-blender/issues",

--- a/io_scene_spm/blender_manifest.toml
+++ b/io_scene_spm/blender_manifest.toml
@@ -2,21 +2,31 @@ schema_version = "1.0.0"
 
 id = "io_scene_spm"
 version = "2.0.0"
-name = "SPM (Space paritioned mesh) format"
+name = "SPM (Space partitioned mesh) format"
 tagline = "Import-Export SPM format objects of SuperTuxKart"
-maintainer = "Richard Qian, LLS"
+maintainer = "Richard Qian, LLS, Alayan"
 
 type = "add-on"
 website = "https://supertuxkart.net/Main_Page.html"
 tags = ["Import-Export"]
 
-blender_version_min = "2.80.0"
+# The extension works with Blender 3.0.0 or greater
+# 4.2.0 is the minimum here because that's the minimum
+# for the new Blender Extensions system
+blender_version_min = "4.2.0"
 # blender_version_max = "5.1.0"
-license = [
-  "SPDX:MIT",
-]
+
+# The addon is actually available under the MIT license.
+# Because the GPL is more restrictive, we can distribute
+# it on Blender Extensions under the terms of the GPL.
+# Users who wish to get it under the MIT license can simply
+# get the code on the official repository.
+license = ['SPDX:GPL-3.0-or-later']
 # # Optional: required by some licenses.
 copyright = [
    "2009-2025 SuperTuxKart-Team",
    "Dev Benau",
 ]
+
+[permissions]
+files = "Import/export SPM files from/to disk"


### PR DESCRIPTION
I chose Blender 3.0.0 rather than 3.2.0 because the proxy was kept solely for backward compatibility in case of problems, but the library was already the main solution.