### PR TITLE
Export Kart

### DIFF
--- a/io_antarctica_scene/stk_kart.py
+++ b/io_antarctica_scene/stk_kart.py
@@ -31,18 +31,18 @@ def saveNitroEmitter(self, f, lNitroEmitter, path):
     if len(lNitroEmitter) > 2:
         self.report({'WARNING'}, " %d nitro emitter specified. Up to 2 are allowed." % len(lNitroEmitter))
         return
-    if len(lNitroEmitter) > 0:	
-	    f.write('  <nitro-emitter>\n')
-	    f.write('    <nitro-emitter-a position = "%f %f %f" />\n' \
-	            % (lNitroEmitter[0].location.x, lNitroEmitter[0].location.z, lNitroEmitter[0].location.y))
-	    f.write('    <nitro-emitter-b position = "%f %f %f" />\n' \
-	            % (lNitroEmitter[1].location.x, lNitroEmitter[1].location.z, lNitroEmitter[1].location.y))
-	    f.write('  </nitro-emitter>\n')
-    #else:
-     #   f.write('  <nitro-emitter>\n')
-	  #  f.write('    <nitro-emitter-a position = "%f %f %f" />\n' \
-	   #         % (lNitroEmitter[0].location.x, lNitroEmitter[0].location.z, lNitroEmitter[0].location.y))
-	    #f.write('  </nitro-emitter>\n')
+    if len(lNitroEmitter) > 0:
+        f.write('  <nitro-emitter>\n')
+        letters = ['a', 'b']
+        for i, nitro in enumerate(lNitroEmitter):  # i is object index
+            f.write('    <nitro-emitter-%s position = "%f %f %f" />\n' \
+                    % (letters[i], nitro.location.x, nitro.location.z, nitro.location.y))
+            if i == 1:
+                f.write('  </nitro-emitter>\n')
+    if len(lNitroEmitter) == 1:
+        f.write('    <nitro-emitter-b position = "%f %f %f" />\n' \
+                    % (lNitroEmitter[0].location.x, lNitroEmitter[0].location.z, lNitroEmitter[0].location.y))
+        f.write('  </nitro-emitter>\n')
         
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The Nitro emitter export function now perfectly handles the case where the designer only creates a single Nitro emitter, by positioning the second one created by the game in exactly the same place defined by the designer.